### PR TITLE
Update cloudwatch log groupe name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ module "aws_cw_logs" {
   create_kms_key              = var.create_kms_key
   log_group_kms_key_id        = var.log_group_kms_key_id
   log_group_retention_in_days = var.log_group_retention_in_days
-  logs_path                   = "/ecs/service/${var.name_prefix}-jenkins-master"
+  logs_path                   = "/ecs/service/${var.name_prefix}-nexus"
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
In the module `aws_cw_logs`, you create a log group name `/ecs/service/${var.name_prefix}-jenkins-master` while in the `fargate`
 module you refer to a log group name `/ecs/service/${var.name_prefix}-nexus`